### PR TITLE
 windows-1251 encoding used for Cyrillic chars

### DIFF
--- a/src/main/java/ee/tkasekamp/vickywaranalyzer/parser/Parser.java
+++ b/src/main/java/ee/tkasekamp/vickywaranalyzer/parser/Parser.java
@@ -79,7 +79,7 @@ public class Parser {
 		WARGOAL_COUNTER = 0;
 		bracketCounter = 0;
 
-		InputStreamReader reader = new InputStreamReader(new FileInputStream(saveGamePath), "ISO8859_1"); // This encoding seems to work for ö
+		InputStreamReader reader = new InputStreamReader(new FileInputStream(saveGamePath), "windows-1251"); // This encoding seems to work for ö
 		BufferedReader scanner = new BufferedReader(reader);
 
 		String line;

--- a/src/main/java/ee/tkasekamp/vickywaranalyzer/util/Localisation.java
+++ b/src/main/java/ee/tkasekamp/vickywaranalyzer/util/Localisation.java
@@ -39,7 +39,7 @@ public class Localisation {
 			throws IOException {
 		/* The same reader as in SaveGameReader */
 		InputStreamReader reader = new InputStreamReader(new FileInputStream(filename),
-				"ISO8859_1"); // This encoding seems to work for ö
+				"windows-1251"); // This encoding seems to work for ö
 		// and ü
 		BufferedReader scanner = new BufferedReader(reader);
 


### PR DESCRIPTION

![PastVersion](https://user-images.githubusercontent.com/30623315/119033152-9120d800-b9b5-11eb-8925-8ee5a8b35536.png)
![How it's now](https://user-images.githubusercontent.com/30623315/119033203-9e3dc700-b9b5-11eb-9e7f-2525296f6c36.PNG)

This commit changes only encoding in two places: from ISO8859_1 to windows-1251. The reason for this change is that ISO does not support Cyrillic characters and Victoria 2 has a huge fan base in Russian-speaking community. There are hundreds of people using it regularly in Post-Soviet territory mostly for Multiplayer Competitive purposes which are using localised version of Victoria 2 so saved games have characters like this: Русско-Турецкая война, which in current version would be displayed something like this: Aaeeeiadeoaiey . Which makes searching for the right war a difficult task. Changing encoding to windows-1251 will not interfere with other latin derived letters.

Thank you for this amazing application, it brought much joy to people who play Victoria 2 multiplayer on a regular basis.
